### PR TITLE
bump version for new hadoop jars with sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ AIQ DEV
 # set the version (bump to the next -aiq#)
 mvn versions:set -DgenerateBackupPoms=false -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
 
-# build, this places artifacts in ~/.m2/repository/org/spark-project/hive/
+# build, this places artifacts in ~/.m2/repository/com/amazonaws/glue/
 mvn clean install -DskipTests -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
 
 # run tests

--- a/README.md
+++ b/README.md
@@ -112,3 +112,22 @@ NOTE: The caching logic is disabled by default. Also, there is no one-size-fits-
 ## License
 
 This library is licensed under the Apache 2.0 License. 
+
+
+========
+AIQ DEV
+========
+# set the version (bump to the next -aiq#)
+mvn versions:set -DgenerateBackupPoms=false -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+
+# build, this places artifacts in ~/.m2/repository/org/spark-project/hive/
+mvn clean install -DskipTests -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+
+# run tests
+mvn test -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+
+# to deploy to S3 at our bucket s3://s3.amazonaws.com/aiq-artifacts/ use:
+mvn deploy -DskipTests -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+
+# Based off of https://nuvalence.io/blog/using-a-s3-bucket-as-a-maven-repository
+# NOTE we put the user/password in ~/.m2/settings.xml so it's not checked in

--- a/aws-glue-datacatalog-client-common/pom.xml
+++ b/aws-glue-datacatalog-client-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-        <version>1.10.0-aiq6</version>
+        <version>1.10.0-aiq7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>AWSGlueDataCatalogClientCommon</name>
@@ -62,11 +62,6 @@
             <groupId>com.amazonaws.glue</groupId>
             <artifactId>shims-loader</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
     </dependencies>
 

--- a/aws-glue-datacatalog-hive2-client/pom.xml
+++ b/aws-glue-datacatalog-hive2-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-        <version>1.10.0-aiq6</version>
+        <version>1.10.0-aiq7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>AWSGlueDataCatalogHive2Client</name>

--- a/aws-glue-datacatalog-spark-client/pom.xml
+++ b/aws-glue-datacatalog-spark-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-        <version>1.10.0-aiq6</version>
+        <version>1.10.0-aiq7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>AWSGlueDataCatalogSparkClient</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.amazonaws.glue</groupId>
   <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-  <version>1.10.0-aiq6</version>
+  <version>1.10.0-aiq7</version>
     <modules>
       <module>aws-glue-datacatalog-client-common</module>
       <module>aws-glue-datacatalog-spark-client</module>
@@ -21,7 +21,7 @@
     <guava.version>20.0</guava.version>
     <hive2.version>2.3.3</hive2.version>
     <!-- https://github.com/ActionIQ-OSS/hive -->
-    <spark-hive.version>1.2.1.spark2-aiq11</spark-hive.version>
+    <spark-hive.version>1.2.1.spark2-aiq12</spark-hive.version>
     <aws.sdk.version>1.11.1034</aws.sdk.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
@@ -112,6 +112,17 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <distributionManagement>
+    <repository>
+      <id>aws-releases</id>
+      <url>s3://aiq-artifacts/releases</url>
+    </repository>
+    <snapshotRepository>
+      <id>aws-snapshots</id>
+      <url>s3://aiq-artifacts/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <build>
     <extensions>
       <extension>
@@ -119,7 +130,27 @@
         <artifactId>aws-maven</artifactId>
         <version>5.0.0.RELEASE</version>
       </extension>
+      <extension>
+        <groupId>com.github.seahen</groupId>
+        <artifactId>maven-s3-wagon</artifactId>
+        <version>1.3.3</version>
+      </extension>
     </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <surefire.version>2.15</surefire.version>
     <powermock.version>1.6.4</powermock.version>
     <!-- https://github.com/ActionIQ/hadoop -->
-    <hadoop.version>2.9.2-aiq8</hadoop.version>
+    <hadoop.version>2.9.2-aiq9</hadoop.version>
     <maven.eclipse.plugin.version>2.9</maven.eclipse.plugin.version>
     <hamcrest.version>1.3</hamcrest.version>
     <httpclient.version>4.5.13</httpclient.version>

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>shims</artifactId>
-        <version>1.10.0-aiq6</version>
+        <version>1.10.0-aiq7</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/hive2-shims/pom.xml
+++ b/shims/hive2-shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>shims</artifactId>
-        <version>1.10.0-aiq6</version>
+        <version>1.10.0-aiq7</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/loader/pom.xml
+++ b/shims/loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>shims</artifactId>
-        <version>1.10.0-aiq6</version>
+        <version>1.10.0-aiq7</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-        <version>1.10.0-aiq6</version>
+        <version>1.10.0-aiq7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shims</artifactId>

--- a/shims/spark-hive-shims/pom.xml
+++ b/shims/spark-hive-shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>shims</artifactId>
-        <version>1.10.0-aiq6</version>
+        <version>1.10.0-aiq7</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Use hadoop with source jars, as deployed by [this PR](https://github.com/ActionIQ/hadoop/pull/9)