### PR TITLE
[EXE-401] Bump AWS sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,20 +114,34 @@ NOTE: The caching logic is disabled by default. Also, there is no one-size-fits-
 This library is licensed under the Apache 2.0 License. 
 
 
-========
-AIQ DEV
-========
-# set the version (bump to the next -aiq#)
+## AIQ DEV
+# Prereqs
+```
+brew install maven
+```
+
+# Version
+Bump to the next `-aiq#` version
+```
 mvn versions:set -DgenerateBackupPoms=false -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+```
 
-# build, this places artifacts in ~/.m2/repository/com/amazonaws/glue/
+# Build
+This places artifacts in `~/.m2/repository/com/amazonaws/glue/`
+```
 mvn clean install -DskipTests -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+```
 
-# run tests
+# Tests
+```
 mvn test -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+```
 
-# to deploy to S3 at our bucket s3://s3.amazonaws.com/aiq-artifacts/ use:
+# Deploy
+To deploy to S3 at our bucket `s3://s3.amazonaws.com/aiq-artifacts`
+```
 mvn deploy -DskipTests -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+```
 
-# Based off of https://nuvalence.io/blog/using-a-s3-bucket-as-a-maven-repository
-# NOTE we put the user/password in ~/.m2/settings.xml so it's not checked in
+Based off of https://nuvalence.io/blog/using-a-s3-bucket-as-a-maven-repository
+Note we put the user/password in ~/.m2/settings.xml so it's not checked in

--- a/README.md
+++ b/README.md
@@ -133,8 +133,14 @@ mvn clean install -DskipTests -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,
 ```
 
 # Tests
+Full tests are expensive to run and flaky
 ```
-mvn test -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+mvn test -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+```
+So you can run individual tests on the projects affected
+```
+cd aws-glue-datacatalog-spark-client/
+mvn test -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
 ```
 
 # Deploy

--- a/aws-glue-datacatalog-client-common/pom.xml
+++ b/aws-glue-datacatalog-client-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-        <version>1.10.0-aiq7</version>
+        <version>1.10.0-aiq8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>AWSGlueDataCatalogClientCommon</name>

--- a/aws-glue-datacatalog-hive2-client/pom.xml
+++ b/aws-glue-datacatalog-hive2-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-        <version>1.10.0-aiq7</version>
+        <version>1.10.0-aiq8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>AWSGlueDataCatalogHive2Client</name>

--- a/aws-glue-datacatalog-spark-client/pom.xml
+++ b/aws-glue-datacatalog-spark-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-        <version>1.10.0-aiq7</version>
+        <version>1.10.0-aiq8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>AWSGlueDataCatalogSparkClient</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,13 @@
     <hive2.version>2.3.3</hive2.version>
     <!-- https://github.com/ActionIQ-OSS/hive -->
     <spark-hive.version>1.2.1.spark2-aiq12</spark-hive.version>
-    <aws.sdk.version>1.11.1034</aws.sdk.version>
+    <aws.sdk.version>1.12.220</aws.sdk.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <surefire.version>2.15</surefire.version>
     <powermock.version>1.6.4</powermock.version>
     <!-- https://github.com/ActionIQ/hadoop -->
-    <hadoop.version>2.9.2-aiq9</hadoop.version>
+    <hadoop.version>2.9.2-aiq10</hadoop.version>
     <maven.eclipse.plugin.version>2.9</maven.eclipse.plugin.version>
     <hamcrest.version>1.3</hamcrest.version>
     <httpclient.version>4.5.13</httpclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.amazonaws.glue</groupId>
   <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-  <version>1.10.0-aiq7</version>
+  <version>1.10.0-aiq8</version>
     <modules>
       <module>aws-glue-datacatalog-client-common</module>
       <module>aws-glue-datacatalog-spark-client</module>

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>shims</artifactId>
-        <version>1.10.0-aiq7</version>
+        <version>1.10.0-aiq8</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/hive2-shims/pom.xml
+++ b/shims/hive2-shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>shims</artifactId>
-        <version>1.10.0-aiq7</version>
+        <version>1.10.0-aiq8</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/loader/pom.xml
+++ b/shims/loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>shims</artifactId>
-        <version>1.10.0-aiq7</version>
+        <version>1.10.0-aiq8</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>aws-glue-datacatalog-hive-client</artifactId>
-        <version>1.10.0-aiq7</version>
+        <version>1.10.0-aiq8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shims</artifactId>

--- a/shims/spark-hive-shims/pom.xml
+++ b/shims/spark-hive-shims/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazonaws.glue</groupId>
         <artifactId>shims</artifactId>
-        <version>1.10.0-aiq7</version>
+        <version>1.10.0-aiq8</version>
         <relativePath>../</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Bumping the version to match our other apps, and pickup https://github.com/ActionIQ/hadoop/pull/10

### Test
```
cd aws-glue-datacatalog-spark-client
mvn test -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] Total time: 14.029 s
[INFO] Finished at: 2022-05-15T13:51:56-05:00
```

### Deploy
Usual deploy (see README)